### PR TITLE
Add Google Drive folder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ python bank_statement_automator.py \
   --output-dir ./saida \
   --bank-creds caminho/credenciais_banco.json \
   --drive-creds caminho/service_account.json \
+  --drive-folder-id 15IK2XcKpNAwH5vd7a05sTyZ0CTPzacLu \
   --sendgrid-key <API_KEY_SENDGRID> \
   --recipients email1@example.com,email2@example.com
 ```
@@ -30,6 +31,8 @@ python bank_statement_automator.py \
   `cert`, `key` e `account` do Banco Inter.
 - **--drive-creds** deve apontar para o arquivo JSON da conta de serviço do
   Google Drive (obtenha em "Google Cloud Console").
+- **--drive-folder-id** ID da pasta no Google Drive onde os arquivos serão enviados
+  (padrão: `15IK2XcKpNAwH5vd7a05sTyZ0CTPzacLu`).
 - **--sendgrid-key** é a chave da API do SendGrid para envio de e-mails.
 - **--recipients** lista de e-mails de destino separada por vírgula.
 


### PR DESCRIPTION
## Summary
- add `DEFAULT_DRIVE_FOLDER_ID`
- allow customizing Google Drive upload folder via `--drive-folder-id`
- upload files to the configured folder
- document drive folder option in README

## Testing
- `python -m py_compile bank_statement_automator.py`
- `pip install -r requirements.txt`
- `python bank_statement_automator.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6844af05b840832fbfd2b7de642aa5c6